### PR TITLE
Node changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,17 +39,23 @@ The generated output contains processed data that our renderer can directly use.
         ip: String,
         betweenness: f64,
         closeness: f64,
-        num_connections: usize,
+        cell_position: u32,
+        cell_height: u32,
+        connections: Vec<usize>,
         geolocation: GeoInfo
-    ],
-    betweenness: Vec<f64>,
-    closeness: Vec<f64>,
-    min_betweenness: f64,
-    max_betweenness: f64,
-    min_closeness: f64,
-    max_closeness: f64
+    ]
 }
 ```
+Explaination of the node fields:
+
+- `ip`: the address as dotted quad, without port number
+- `betweenness`: the computed betweenness
+- `closeness`: the computed closeness
+- `cell_position`: corresponds to the z-coordinate positioning of a given node.
+- `cell_height`: indicated the total number of nodes in a given cell (like a vertical column).
+- `connections`: an array of indices corresponding to the connected nodes.
+- `geolocation`: used for latitude, longitude, city, country
+
 
 ### Command Line
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Explaination of the node fields:
 - `connections`: an array of indices corresponding to the connected nodes.
 - `geolocation`: used for latitude, longitude, city, country
 
+### More about `cell`:
+Nodes at the same (or nearly the same) geolocation get grouped into a cell. This results in rendering a column of nodes, where each node gets its own position coordinate assigned. We use 0.2 degree granularity in both axes to determine cell membership.
 
 ### Command Line
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,6 @@ use crate::config::CrunchyConfiguration;
 use crate::nodes::{create_nodes, Node};
 use serde::{Deserialize, Serialize};
 use spectre::graph::AGraph;
-// use ziggurat_core_geoip::geoip::GeoInfo;
 use ziggurat_core_geoip::providers::ip2loc::Ip2LocationService;
 use ziggurat_core_geoip::providers::ipgeoloc::{BackendProvider, IpGeolocateService};
 
@@ -205,13 +204,9 @@ mod tests {
         let size: usize = 2531;
         assert_eq!(state.agraph_length, size);
         assert_eq!(state.nodes.len(), size);
-        // assert!((state.min_betweenness - 0.0).abs() < f64::EPSILON);
-        // assert!((state.max_betweenness - 0.0006471174062683313).abs() < f64::EPSILON);
-        // assert!((state.min_closeness - 1.9965036212494205).abs() < f64::EPSILON);
-        // assert!((state.max_closeness - 2.9965618988763065).abs() < f64::EPSILON);
         let node = state.nodes[5].clone();
         assert_eq!(node.ip, "38.242.199.182");
-        // assert_eq!(node.num_onnections, 378);
+        assert_eq!(node.connections.len(), 378);
         assert!((node.betweenness - 0.000244483600836513).abs() < f64::EPSILON);
         assert!((node.closeness - 2.0013493455674).abs() < f64::EPSILON);
     }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -17,6 +17,13 @@ pub struct Node {
     pub geolocation: Option<GeoInfo>,
 }
 
+fn hash_geo_location(latitude: f64, longitude: f64) -> String {
+    // make unique every 0.2, so multiply by 5, convert to integer
+    let ilatitude: i32 = (latitude * 5.0).floor() as i32;
+    let ilongitude: i32 = (longitude * 5.0).floor() as i32;
+    format!("{ilatitude}:{ilongitude}")
+}
+
 // essentially, we sort the nodes into groups at (nearly) same geo-location
 // we use 0.2 degrees for epsilon in both axes.
 // hash gets created from a string created by two numbers
@@ -27,10 +34,7 @@ pub fn set_column_positions(nodes: &mut Vec<Node>) -> HashMap<String, u32> {
         if let Some(geoinfo) = &node.geolocation {
             if let Some(latitude) = geoinfo.latitude {
                 if let Some(longitude) = geoinfo.longitude {
-                    // make unique every 0.2, so multiply by 5, convert to integer
-                    let ilatitude: i32 = (latitude * 5.0).floor() as i32;
-                    let ilongitude: i32 = (longitude * 5.0).floor() as i32;
-                    let geostr = format!("{ilatitude}:{ilongitude}");
+                    let geostr = hash_geo_location(latitude, longitude);
                     column_stats
                         .entry(geostr.clone())
                         .and_modify(|count| *count += 1)
@@ -50,9 +54,7 @@ pub fn set_column_sizes(nodes: &mut Vec<Node>, column_stats: &mut HashMap<String
         if let Some(geoinfo) = &node.geolocation {
             if let Some(latitude) = geoinfo.latitude {
                 if let Some(longitude) = geoinfo.longitude {
-                    let ilatitude: i32 = (latitude * 5.0).floor() as i32;
-                    let ilongitude: i32 = (longitude * 5.0).floor() as i32;
-                    let geostr = format!("{ilatitude}:{ilongitude}");
+                    let geostr = hash_geo_location(latitude, longitude);
                     if let Some(count) = column_stats.get(&geostr) {
                         node.column_size = *count;
                     }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -30,7 +30,7 @@ pub fn set_column_positions(nodes: &mut Vec<Node>) -> HashMap<String, u32> {
                     // make unique every 0.2, so multiply by 5, convert to integer
                     let ilatitude: i32 = (latitude * 5.0).floor() as i32;
                     let ilongitude: i32 = (longitude * 5.0).floor() as i32;
-                    let geostr = format!("{}:{}", ilatitude, ilongitude);
+                    let geostr = format!("{ilatitude}:{ilongitude}");
                     column_stats
                         .entry(geostr.clone())
                         .and_modify(|count| *count += 1)
@@ -52,7 +52,7 @@ pub fn set_column_sizes(nodes: &mut Vec<Node>, column_stats: &mut HashMap<String
                 if let Some(longitude) = geoinfo.longitude {
                     let ilatitude: i32 = (latitude * 5.0).floor() as i32;
                     let ilongitude: i32 = (longitude * 5.0).floor() as i32;
-                    let geostr = format!("{}:{}", ilatitude, ilongitude);
+                    let geostr = format!("{ilatitude}:{ilongitude}");
                     if let Some(count) = column_stats.get(&geostr) {
                         node.column_size = *count;
                     }

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -59,11 +59,11 @@ pub fn set_column_sizes(nodes: &mut Vec<Node>, column_stats: &mut HashMap<String
 
 pub async fn create_nodes(
     agraph: &Vec<Vec<usize>>,
-    node_ips: &Vec<String>,
+    node_ips: &[String],
     geo_cache: &GeoIPCache,
 ) -> Vec<Node> {
     let graph: Graph<usize> = Graph::new();
-    let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+    let (betweenness, closeness) = graph.compute_betweenness_and_closeness(agraph);
     let mut nodes = Vec::with_capacity(agraph.len());
     for i in 0..agraph.len() {
         let node: Node = Node {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -4,7 +4,7 @@ use ziggurat_core_geoip::geoip::GeoInfo;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use spectre::graph::{Graph, AGraph};
+use spectre::graph::{AGraph, Graph};
 
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Node {

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -1,0 +1,86 @@
+use crate::geoip_cache::GeoIPCache;
+use ziggurat_core_geoip::geoip::GeoInfo;
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use spectre::graph::Graph;
+
+//TODO(asmie): there is some redundancy here as we have ip in the Node structure and one more time
+// in the GeoIPInfo structure.
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct Node {
+    pub ip: String,
+    pub betweenness: f64,
+    pub closeness: f64,
+    pub column_position: u32,
+    pub column_size: u32,
+    pub connections: Vec<usize>,
+    pub geolocation: Option<GeoInfo>,
+}
+
+pub fn compute_columns(nodes: &mut Vec<Node>) -> HashMap<String, u32> {
+    let mut column_stats: HashMap<String, u32> = HashMap::new();
+    for node in nodes {
+        if let Some(geoinfo) = &node.geolocation {
+            if let Some(latitude) = geoinfo.latitude {
+                if let Some(longitude) = geoinfo.longitude {
+                    let ilatitude: i32 = (latitude * 5.0).floor() as i32;
+                    let ilongitude: i32 = (longitude * 5.0).floor() as i32;
+                    let geostr = format!("{}:{}", ilatitude, ilongitude);
+                    column_stats
+                        .entry(geostr.clone())
+                        .and_modify(|count| *count += 1)
+                        .or_insert(1);
+                    node.column_position = column_stats[&geostr];
+                }
+            }
+        }
+    }
+    column_stats
+}
+
+pub fn set_column_sizes(nodes: &mut Vec<Node>, column_stats: &mut HashMap<String, u32>) {
+    for node in nodes {
+        if let Some(geoinfo) = &node.geolocation {
+            if let Some(latitude) = geoinfo.latitude {
+                if let Some(longitude) = geoinfo.longitude {
+                    let ilatitude: i32 = (latitude * 5.0).floor() as i32;
+                    let ilongitude: i32 = (longitude * 5.0).floor() as i32;
+                    let geostr = format!("{}:{}", ilatitude, ilongitude);
+                    if let Some(count) = column_stats.get(&geostr) {
+                        node.column_size = *count;
+                    }
+                }
+            }
+        }
+    }
+}
+
+pub async fn create_nodes(
+    agraph: &Vec<Vec<usize>>,
+    node_ips: &Vec<String>,
+    geo_cache: &GeoIPCache,
+) -> Vec<Node> {
+    let graph: Graph<usize> = Graph::new();
+    let (betweenness, closeness) = graph.compute_betweenness_and_closeness(&agraph);
+    let mut nodes = Vec::with_capacity(agraph.len());
+    for i in 0..agraph.len() {
+        let node: Node = Node {
+            ip: node_ips[i].clone(),
+            betweenness: betweenness[i],
+            closeness: closeness[i],
+            column_position: 0,
+            column_size: 0,
+            connections: agraph[i].clone(),
+            geolocation: geo_cache
+                .lookup(node_ips[i].parse().expect("malformed IP address"))
+                .await,
+        };
+        nodes.push(node);
+    }
+
+    let mut column_stats = compute_columns(&mut nodes);
+    set_column_sizes(&mut nodes, &mut column_stats);
+    nodes
+}

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -4,7 +4,7 @@ use ziggurat_core_geoip::geoip::GeoInfo;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use spectre::graph::Graph;
+use spectre::graph::{Graph, AGraph};
 
 #[derive(Default, Clone, Serialize, Deserialize)]
 pub struct Node {
@@ -19,8 +19,8 @@ pub struct Node {
 
 fn hash_geo_location(latitude: f64, longitude: f64) -> String {
     // make unique every 0.2, so multiply by 5, convert to integer
-    let ilatitude: i32 = (latitude * 5.0).floor() as i32;
-    let ilongitude: i32 = (longitude * 5.0).floor() as i32;
+    let ilatitude = (latitude * 5.0).floor() as i32;
+    let ilongitude = (longitude * 5.0).floor() as i32;
     format!("{ilatitude}:{ilongitude}")
 }
 
@@ -29,7 +29,7 @@ fn hash_geo_location(latitude: f64, longitude: f64) -> String {
 // hash gets created from a string created by two numbers
 // increment each time the same location is found
 pub fn set_column_positions(nodes: &mut Vec<Node>) -> HashMap<String, u32> {
-    let mut column_stats: HashMap<String, u32> = HashMap::new();
+    let mut column_stats = HashMap::new();
     for node in nodes {
         if let Some(geoinfo) = &node.geolocation {
             if let Some(latitude) = geoinfo.latitude {
@@ -65,7 +65,7 @@ pub fn set_column_sizes(nodes: &mut Vec<Node>, column_stats: &mut HashMap<String
 }
 
 pub async fn create_nodes(
-    agraph: &Vec<Vec<usize>>,
+    agraph: &AGraph,
     node_ips: &[String],
     geo_cache: &GeoIPCache,
 ) -> Vec<Node> {


### PR DESCRIPTION
This PR has two main parts
- compute and assign column position and size fields to Node structure.  This data is used by the renderer to position the node vertically, when many nodes are at a single geo-location (e.g., in a column).  At its core, this process involves sorting the nodes by geo-location.
- moved the node creation into a separate module, so main.rs is a bit less cluttered now.  This refactoring will continue in future revisions.
