### PR TITLE
feat: interconnected islands bridges detection

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -77,6 +77,8 @@ pub struct IPSConfiguration {
     pub change_at_least: u32,
     /// Indicates maximum peers should be changed for each node
     pub change_no_more: u32,
+    /// Indicates adjustment factor for bridge detection
+    pub bridge_threshold_adjustment: f64,
     /// Multi-criteria analysis weights
     pub mcda_weights: MultiCriteriaAnalysisWeights,
 }
@@ -124,6 +126,7 @@ impl Default for IPSConfiguration {
             change_at_least: 1,
             change_no_more: 2,
             mcda_weights: MultiCriteriaAnalysisWeights::default(),
+            bridge_threshold_adjustment: 1.25,
         }
     }
 }

--- a/src/graph_utils.rs
+++ b/src/graph_utils.rs
@@ -21,11 +21,17 @@ use crate::{utils::median, Node};
 /// with similar betweenness centrality taking top 20% would result in finding fake bridges).
 pub fn find_bridges(nodes: &[Node], threshold_adjustment: f64) -> HashMap<usize, HashSet<usize>> {
     let mut bridges = HashMap::new();
+
+    // If there are less than 2 nodes there is no point in finding bridges.
+    if nodes.len() < 2 {
+        return bridges;
+    }
+
     let mut betweenness_list = nodes.iter().map(|n| n.betweenness).collect::<Vec<f64>>();
 
     betweenness_list.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
-    let betweenness_median = median(&betweenness_list);
+    let betweenness_median = median(&betweenness_list).unwrap(); // Safe to uwrap as we checked if there are at least 2 nodes.
     let betweenness_threshold = betweenness_median * threshold_adjustment;
 
     for (node_idx, node) in nodes.iter().enumerate() {

--- a/src/graph_utils.rs
+++ b/src/graph_utils.rs
@@ -40,7 +40,7 @@ pub fn find_bridges(nodes: &[Node], threshold_adjustment: f64) -> HashMap<usize,
         }
 
         for peer_idx in &node.connections {
-            if nodes[*peer_idx].betweenness < betweenness_threshold || node_idx == *peer_idx {
+            if nodes[*peer_idx].betweenness <= betweenness_threshold {
                 continue;
             }
 

--- a/src/graph_utils.rs
+++ b/src/graph_utils.rs
@@ -1,0 +1,124 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{utils::median, Node};
+
+/// Find bridges in graph.
+/// Bridges are edges that if removed disconnects the graph but here we try to find something
+/// similar to bridges - connections that acts like bridges between two inter-connected islands
+/// but cutting them do not disconnect the graph (as there can be couple of bridges for each
+/// interconnected island). That is why we use betweenness centrality to find such connections
+/// instead of some popular bridge finding algorithms (like Tarjan's algorithm or chain
+/// decomposition).
+///
+/// The idea is to find connections that have high betweenness centrality on both ends. The main
+/// problem is meaning of high betweenness centrality. This approach uses median of betweenness
+/// centrality of all nodes as a base point for threshold. Then, to eliminate some corner cases
+/// (eg. when there are only few nodes with high betweenness centrality and most of the nodes have
+/// low factor value what could result in finding too many bridges) we adjust the threshold by
+/// const factor read from configuration. There could be different approaches like not using
+/// the median but taking value from some percentile (eg. 90th percentile) but this could lead to
+/// set threshold to find too many bridges in case of eg. balanced graph (if there are many nodes
+/// with similar betweenness centrality taking top 20% would result in finding fake bridges).
+pub fn find_bridges(nodes: &[Node], threshold_adjustment: f64) -> HashMap<usize, HashSet<usize>> {
+    let mut bridges = HashMap::new();
+    let mut betweenness_list = nodes.iter().map(|n| n.betweenness).collect::<Vec<f64>>();
+
+    betweenness_list.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let betweenness_median = median(&betweenness_list);
+    let betweenness_threshold = betweenness_median * threshold_adjustment;
+
+    for (node_idx, node) in nodes.iter().enumerate() {
+        if node.betweenness < betweenness_threshold {
+            continue;
+        }
+
+        for peer_idx in &node.connections {
+            if nodes[*peer_idx].betweenness < betweenness_threshold || node_idx == *peer_idx {
+                continue;
+            }
+
+            bridges
+                .entry(node_idx)
+                .and_modify(|peers: &mut HashSet<usize>| {
+                    peers.insert(*peer_idx);
+                })
+                .or_insert(HashSet::new())
+                .insert(*peer_idx);
+
+            bridges
+                .entry(*peer_idx)
+                .and_modify(|peers: &mut HashSet<usize>| {
+                    peers.insert(node_idx);
+                })
+                .or_insert(HashSet::new())
+                .insert(node_idx);
+        }
+    }
+    bridges
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_bridges_test() {
+        let nodes = vec![
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 1.0,
+                connections: vec![1, 2],
+                ..Default::default()
+            },
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 1.5,
+                connections: vec![0, 2, 3],
+                ..Default::default()
+            },
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 1.3,
+                connections: vec![1, 3],
+                ..Default::default()
+            },
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 3.1,
+                connections: vec![1, 2, 4],
+                ..Default::default()
+            },
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 3.2,
+                connections: vec![3, 5, 7],
+                ..Default::default()
+            },
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 1.0,
+                connections: vec![4, 6],
+                ..Default::default()
+            },
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 1.2,
+                connections: vec![5, 7],
+                ..Default::default()
+            },
+            Node {
+                ip: "0.0.0.0".to_string(),
+                betweenness: 1.4,
+                connections: vec![4, 6],
+                ..Default::default()
+            },
+        ];
+
+        let bridges = find_bridges(&nodes, 1.25);
+        assert!(bridges.contains_key(&3));
+        let peers = bridges.get(&3).unwrap();
+        assert_eq!(peers.len(), 1);
+        assert!(peers.contains(&4));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 mod config;
 mod geoip_cache;
+mod graph_utils;
 mod ips;
 mod nodes;
+mod utils;
 
 use std::{fs, path::PathBuf, time::Instant};
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,15 @@
+/// Calculates the median of a list of numbers.
+pub fn median<T>(list: &[T]) -> f64
+where
+    T: PartialOrd + Into<f64> + Copy,
+{
+    let mut list = list.to_vec();
+    list.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let mid = list.len() / 2;
+    if list.len() % 2 == 0 {
+        (list[mid - 1].into() + list[mid].into()) / 2.0
+    } else {
+        list[mid].into()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,15 +1,45 @@
 /// Calculates the median of a list of numbers.
-pub fn median<T>(list: &[T]) -> f64
+pub fn median<T>(list: &[T]) -> Option<f64>
 where
     T: PartialOrd + Into<f64> + Copy,
 {
+    if list.is_empty() {
+        return None;
+    }
+
     let mut list = list.to_vec();
     list.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
     let mid = list.len() / 2;
     if list.len() % 2 == 0 {
-        (list[mid - 1].into() + list[mid].into()) / 2.0
+        Some((list[mid - 1].into() + list[mid].into()) / 2.0)
     } else {
-        list[mid].into()
+        Some(list[mid].into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn median_test() {
+        let list = vec![10];
+        assert_eq!(median(&list).unwrap(), 10.0);
+
+        let list = vec![1, 2, 3, 4, 5];
+        assert_eq!(median(&list).unwrap(), 3.0);
+
+        let list = vec![1, 2, 3, 4, 5, 6];
+        assert_eq!(median(&list).unwrap(), 3.5);
+
+        let list = vec![1, 2, 3, 4, 5, 6, 7];
+        assert_eq!(median(&list).unwrap(), 4.0);
+    }
+
+    #[test]
+    fn median_test_empty() {
+        let list = Vec::<f64>::new();
+        assert!(median(&list).is_none());
     }
 }

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -15,6 +15,7 @@ geolocation = "PreferCloser"
 geolocation_minmax_distance_km = 1000
 change_at_least = 1
 change_no_more = 2
+bridge_threshold_adjustment = 1.25
 
 [ips_config.mcda_weights]
 location = 0.3


### PR DESCRIPTION
Find bridges in graph.
Bridges are edges that if removed disconnects the graph but here we try to find something similar to bridges - connections that acts like bridges between two inter-connected islandsbut cutting them do not disconnect the graph (as there can be couple of bridges for each interconnected island). That is why we use betweenness centrality to find such connections instead of some popular bridge finding algorithms (like Tarjan's algorithm or chain decomposition).

The idea is to find connections that have high betweenness centrality on both ends. The main problem is meaning of high betweenness centrality. This approach uses median of betweenness centrality of all nodes as a base point for threshold. Then, to eliminate some corner cases (eg. when there are only few nodes with high betweenness centrality and most of the nodes have low factor value what could result in finding too many bridges) we adjust the threshold by const factor read from configuration. There could be different approaches like not using the median but taking value from some percentile (eg. 90th percentile) but this could lead to set threshold to find too many bridges in case of eg. balanced graph (if there are many nodes with similar betweenness centrality taking top 20% would result in finding fake bridges).

This PR introduces bridge detection and ensurance that bridge is never deleted.