### PR TITLE
refactor: cutting main functions (write_state, generate) into smaller ones (1/2)

### DIFF
--- a/src/geoip_cache.rs
+++ b/src/geoip_cache.rs
@@ -9,7 +9,13 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
-use ziggurat_core_geoip::geoip::{GeoIPService, GeoInfo};
+use ziggurat_core_geoip::{
+    geoip::{GeoIPService, GeoInfo},
+    providers::{
+        ip2loc::Ip2LocationService,
+        ipgeoloc::{BackendProvider, IpGeolocateService},
+    },
+};
 
 use crate::config::{GeoIPConfiguration, DEFAULT_KEEP_IN_CACHE_DAYS};
 
@@ -116,5 +122,33 @@ impl GeoIPCache {
         }
 
         None
+    }
+
+    /// Configure the providers based on the configuration.
+    pub fn configure_providers(&mut self, config: &GeoIPConfiguration) {
+        if config.ip2location_enable {
+            self.add_provider(Box::new(Ip2LocationService::new(
+                config
+                    .ip2location_db_path
+                    .as_ref()
+                    .unwrap()
+                    .to_str()
+                    .unwrap(),
+            )));
+        }
+
+        if config.ipapico_enable {
+            self.add_provider(Box::new(IpGeolocateService::new(
+                BackendProvider::IpApiCo,
+                config.ipapico_api_key.as_ref().unwrap().as_str(),
+            )));
+        }
+
+        if config.ipapicom_enable {
+            self.add_provider(Box::new(IpGeolocateService::new(
+                BackendProvider::IpApiCom,
+                config.ipapicom_api_key.as_ref().unwrap().as_str(),
+            )));
+        }
     }
 }

--- a/src/graph_utils.rs
+++ b/src/graph_utils.rs
@@ -70,6 +70,8 @@ pub fn find_bridges(nodes: &[Node], threshold_adjustment: f64) -> HashMap<usize,
     bridges
 }
 
+/// Reconstruct graph from nodes and their connection subfield. This step is used to run
+/// some graph algorithms on the graph (like betweenness centrality).
 pub fn construct_graph(nodes: &[Node]) -> Graph<IpAddr> {
     let mut graph = Graph::new();
 

--- a/src/ips.rs
+++ b/src/ips.rs
@@ -394,7 +394,7 @@ impl Ips {
     }
 
     fn degree_centrality_avg(&self, degrees: &HashMap<IpAddr, u32>) -> f64 {
-        if degrees.len() < 1 {
+        if degrees.is_empty() {
             return 0.0;
         }
 
@@ -531,10 +531,14 @@ mod tests {
             },
         ];
 
-        let peer = ips.generate_peerlist_for_node(&nodes.get(0).unwrap(), &nodes);
+        let peer = ips.generate_peerlist_for_node(nodes.get(0).unwrap(), &nodes);
         assert_eq!(peer.list.len(), 2);
-        assert!(peer.list.contains(&IpAddr::from_str(&nodes.get(1).unwrap().ip).unwrap()));
-        assert!(peer.list.contains(&IpAddr::from_str(&nodes.get(2).unwrap().ip).unwrap()));
+        assert!(peer
+            .list
+            .contains(&IpAddr::from_str(&nodes.get(1).unwrap().ip).unwrap()));
+        assert!(peer
+            .list
+            .contains(&IpAddr::from_str(&nodes.get(2).unwrap().ip).unwrap()));
     }
 
     #[test]
@@ -562,7 +566,7 @@ mod tests {
 
         let state = ips.generate_state(&nodes);
 
-        assert_eq!(ips.rate_node(&nodes.get(0).unwrap(), &state), 10.0);
+        assert_eq!(ips.rate_node(nodes.get(0).unwrap(), &state), 10.0);
     }
 
     #[test]

--- a/src/ips.rs
+++ b/src/ips.rs
@@ -290,7 +290,7 @@ impl Ips {
     /// Calculates const factors for each node.
     fn calculate_const_factors(&self, state: &IpsState) -> Vec<PeerEntry> {
         let mut const_factors = Vec::with_capacity(state.nodes.len());
-        
+
         for (idx, node) in state.nodes.iter().enumerate() {
             let ip = IpAddr::from_str(node.ip.as_str()).expect(ERR_PARSE_IP);
             const_factors.push(PeerEntry {

--- a/src/ips.rs
+++ b/src/ips.rs
@@ -92,8 +92,11 @@ impl Ips {
         let initial_state = self.generate_state(&state.nodes);
 
         // This is the working set of factors.
-        //TODO(asmie): add .clone() to the initial_state when it will be used
+        //TODO(asmie): add .clone() to the initial_state when it will be used and remove creating new vector
+        // Now we're creating a new vector because MCDA code operates not on state but on the peerlist
+        // and if we left here peerlist from the state, it would be doubled by MCDA.
         let mut working_state = initial_state;
+        working_state.peer_list = Vec::new();
 
         // Phase 1: Security checks
         //TODO(asmie): Detecting islands, bridges and hot nodes. Checking if there are any nodes that upon removal
@@ -163,6 +166,9 @@ impl Ips {
             let desired_degree = ((degree_avg + degree as f64) / 2.0).round() as u32;
 
             // 3 - Calculate how many peers to add or delete from peerlist
+            //TODO(asmie): when graph has been visualized it occured that it has many nodes with
+            // self connections. This is not good as it takes place in peerlist and gives no
+            // benefit.
             let mut peers_to_delete_count = if desired_degree < degree {
                 degree.saturating_sub(desired_degree)
             } else {

--- a/src/ips.rs
+++ b/src/ips.rs
@@ -84,9 +84,6 @@ impl Ips {
     }
 
     /// Generate peer list - main function with The Algorithm
-    /// It needs state and agraph to be passed as parameters which need to be correlated with
-    /// the crawler's state and agraph (and with each other), so the indexes saved in the
-    /// agraph are the same as the positions of the nodes in the state.nodes.
     pub async fn generate(&mut self, state: &CrunchyState) -> Vec<Peer> {
         // Initial state will be used to compare the results of the computations
         let initial_state = self.generate_state(&state.nodes);
@@ -297,8 +294,8 @@ impl Ips {
         // Recalculate factors with new graph
         for node in ips_state.nodes.iter_mut() {
             let ip = IpAddr::from_str(&node.ip).unwrap();
-            node.betweenness = *betweenness.get(&ip).unwrap_or(&0.0);
-            node.closeness = *closeness.get(&ip).unwrap_or(&0.0);
+            node.betweenness = *betweenness.get(&ip).expect("can't fetch betweenness");
+            node.closeness = *closeness.get(&ip).expect("can't fetch closeness");
         }
 
         ips_state.degrees = graph.degree_centrality();

--- a/src/ips.rs
+++ b/src/ips.rs
@@ -282,7 +282,7 @@ impl Ips {
         let closeness = &nodes.iter().map(|n| n.closeness).collect::<Vec<f64>>();
         ips_state.closeness_factors = NormalizationFactors::determine(closeness);
 
-        ips_state.peer_list = Peer::generate_peerlist(nodes);
+        ips_state.peer_list = Peer::generate_all_peerlists(nodes);
 
         ips_state
     }
@@ -290,6 +290,7 @@ impl Ips {
     /// Calculates const factors for each node.
     fn calculate_const_factors(&self, state: &IpsState) -> Vec<PeerEntry> {
         let mut const_factors = Vec::with_capacity(state.nodes.len());
+        
         for (idx, node) in state.nodes.iter().enumerate() {
             let ip = IpAddr::from_str(node.ip.as_str()).expect(ERR_PARSE_IP);
             const_factors.push(PeerEntry {

--- a/src/ips.rs
+++ b/src/ips.rs
@@ -16,11 +16,10 @@ use std::{
     str::FromStr,
 };
 
-use serde::{Deserialize, Serialize};
-
 use crate::{
     config::{GeoLocationMode, IPSConfiguration},
     graph_utils::{construct_graph, find_bridges},
+    peer::Peer,
     CrunchyState, Node,
 };
 
@@ -41,15 +40,6 @@ struct IpsState {
     pub betweenness_factors: NormalizationFactors,
     pub closeness_factors: NormalizationFactors,
     pub eigenvector_factors: NormalizationFactors,
-}
-
-/// Peer list structure containing peer list for each node
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Peer {
-    /// IP address of the node
-    pub ip: IpAddr,
-    /// List of peers for the node
-    pub list: Vec<IpAddr>,
 }
 
 /// Internal structure for storing peer information
@@ -253,37 +243,6 @@ impl Ips {
 
     // Helper functions
 
-    /// Generate peerlist for given nodes based on their connections
-    fn generate_peerlist(&self, nodes: &[Node]) -> Vec<Peer> {
-        let mut peer_list = Vec::with_capacity(nodes.len());
-
-        for node in nodes {
-            peer_list.push(self.generate_peerlist_for_node(node, nodes));
-        }
-
-        peer_list
-    }
-
-    /// Generate peerlist for given node based on its connections
-    fn generate_peerlist_for_node(&self, node: &Node, nodes: &[Node]) -> Peer {
-        let mut peer_list_entry = Peer {
-            ip: IpAddr::from_str(node.ip.as_str()).expect(ERR_PARSE_IP),
-            list: Vec::with_capacity(node.connections.len()),
-        };
-
-        for peer in &node.connections {
-            if *peer >= nodes.len() {
-                continue;
-            }
-
-            peer_list_entry
-                .list
-                .push(IpAddr::from_str(nodes[*peer].ip.as_str()).expect(ERR_PARSE_IP));
-        }
-
-        peer_list_entry
-    }
-
     /// Generate state for IPS
     fn generate_state(&self, nodes: &[Node]) -> IpsState {
         let mut ips_state = IpsState {
@@ -323,7 +282,7 @@ impl Ips {
         let closeness = &nodes.iter().map(|n| n.closeness).collect::<Vec<f64>>();
         ips_state.closeness_factors = NormalizationFactors::determine(closeness);
 
-        ips_state.peer_list = self.generate_peerlist(nodes);
+        ips_state.peer_list = Peer::generate_peerlist(nodes);
 
         ips_state
     }
@@ -507,39 +466,6 @@ mod tests {
     use spectre::{edge::Edge, graph::Graph};
 
     use super::*;
-
-    #[test]
-    fn generate_peerlist_for_node_test() {
-        let ips_config = IPSConfiguration::default();
-        let ips = Ips::new(ips_config);
-
-        let nodes = vec![
-            Node {
-                ip: "0.0.0.0".to_string(),
-                connections: vec![1, 2],
-                ..Default::default()
-            },
-            Node {
-                ip: "1.0.0.0".to_string(),
-                connections: vec![0, 2],
-                ..Default::default()
-            },
-            Node {
-                ip: "2.0.0.0".to_string(),
-                connections: vec![0, 1],
-                ..Default::default()
-            },
-        ];
-
-        let peer = ips.generate_peerlist_for_node(nodes.get(0).unwrap(), &nodes);
-        assert_eq!(peer.list.len(), 2);
-        assert!(peer
-            .list
-            .contains(&IpAddr::from_str(&nodes.get(1).unwrap().ip).unwrap()));
-        assert!(peer
-            .list
-            .contains(&IpAddr::from_str(&nodes.get(2).unwrap().ip).unwrap()));
-    }
 
     #[test]
     fn rate_node_test() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod geoip_cache;
 mod graph_utils;
 mod ips;
 mod nodes;
+mod peer;
 mod utils;
 
 use std::{fs, path::PathBuf, time::Instant};

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,10 +10,6 @@ use std::{fs, path::PathBuf, time::Instant};
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 use ziggurat_core_crawler::summary::NetworkSummary;
-use ziggurat_core_geoip::providers::{
-    ip2loc::Ip2LocationService,
-    ipgeoloc::{BackendProvider, IpGeolocateService},
-};
 
 use crate::{
     config::CrunchyConfiguration,
@@ -46,10 +42,7 @@ pub fn load_state(filepath: &str) -> CrunchyState {
     serde_json::from_str(&jstring).unwrap()
 }
 
-//TODO(asmie): this NEED to be refactorized as currently it is method-level smell (too long)
-// doing too many things. Especially, when I'd like to add here some other stuff like peer sharing it would
-// be too messy. It should be re-designed and divided into smaller functions with appropriate names and
-// functionalities (like computing graphs, counting factors, geolocalization etc).
+/// Perform all the necessary steps to generate the state file and the peer list.
 async fn write_state(config: &CrunchyConfiguration) {
     let mut geo_cache = GeoIPCache::new(&config.geoip_config);
     let response = load_response(config.input_file_path.as_ref().unwrap().to_str().unwrap());
@@ -61,41 +54,7 @@ async fn write_state(config: &CrunchyConfiguration) {
         println!("No cache file to load! Will be created one.");
     }
 
-    if config.geoip_config.ip2location_enable {
-        geo_cache.add_provider(Box::new(Ip2LocationService::new(
-            config
-                .geoip_config
-                .ip2location_db_path
-                .as_ref()
-                .unwrap()
-                .to_str()
-                .unwrap(),
-        )));
-    }
-
-    if config.geoip_config.ipapico_enable {
-        geo_cache.add_provider(Box::new(IpGeolocateService::new(
-            BackendProvider::IpApiCo,
-            config
-                .geoip_config
-                .ipapico_api_key
-                .as_ref()
-                .unwrap()
-                .as_str(),
-        )));
-    }
-
-    if config.geoip_config.ipapicom_enable {
-        geo_cache.add_provider(Box::new(IpGeolocateService::new(
-            BackendProvider::IpApiCom,
-            config
-                .geoip_config
-                .ipapicom_api_key
-                .as_ref()
-                .unwrap()
-                .as_str(),
-        )));
-    }
+    geo_cache.configure_providers(&config.geoip_config);
 
     let nodes = create_nodes(
         &response.result.indices,

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -15,18 +15,18 @@ pub struct Peer {
 
 impl Peer {
     /// Generate peerlist for given nodes based on their connections
-    pub fn generate_peerlist(nodes: &[Node]) -> Vec<Peer> {
+    pub fn generate_all_peerlists(nodes: &[Node]) -> Vec<Peer> {
         let mut peer_list = Vec::with_capacity(nodes.len());
 
         for node in nodes {
-            peer_list.push(Peer::generate_peerlist_for_node(node, nodes));
+            peer_list.push(Peer::generate_peerlist(node, nodes));
         }
 
         peer_list
     }
 
     /// Generate peerlist for given node based on its connections
-    pub fn generate_peerlist_for_node(node: &Node, nodes: &[Node]) -> Peer {
+    pub fn generate_peerlist(node: &Node, nodes: &[Node]) -> Peer {
         let mut peer_list_entry = Peer {
             ip: IpAddr::from_str(node.ip.as_str()).expect(ERR_PARSE_IP),
             list: Vec::with_capacity(node.connections.len()),
@@ -70,7 +70,7 @@ mod tests {
             },
         ];
 
-        let peer = Peer::generate_peerlist_for_node(nodes.get(0).unwrap(), &nodes);
+        let peer = Peer::generate_peerlist(nodes.get(0).unwrap(), &nodes);
         assert_eq!(peer.list.len(), 2);
         assert!(peer
             .list

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,0 +1,82 @@
+use std::{net::IpAddr, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{ips::ERR_PARSE_IP, Node};
+
+/// Peer list structure containing peer list for each node
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Peer {
+    /// IP address of the node
+    pub ip: IpAddr,
+    /// List of peers for the node
+    pub list: Vec<IpAddr>,
+}
+
+impl Peer {
+    /// Generate peerlist for given nodes based on their connections
+    pub fn generate_peerlist(nodes: &[Node]) -> Vec<Peer> {
+        let mut peer_list = Vec::with_capacity(nodes.len());
+
+        for node in nodes {
+            peer_list.push(Peer::generate_peerlist_for_node(node, nodes));
+        }
+
+        peer_list
+    }
+
+    /// Generate peerlist for given node based on its connections
+    pub fn generate_peerlist_for_node(node: &Node, nodes: &[Node]) -> Peer {
+        let mut peer_list_entry = Peer {
+            ip: IpAddr::from_str(node.ip.as_str()).expect(ERR_PARSE_IP),
+            list: Vec::with_capacity(node.connections.len()),
+        };
+
+        for peer in &node.connections {
+            if *peer >= nodes.len() {
+                continue;
+            }
+
+            peer_list_entry
+                .list
+                .push(IpAddr::from_str(nodes[*peer].ip.as_str()).expect(ERR_PARSE_IP));
+        }
+
+        peer_list_entry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_peerlist_for_node_test() {
+        let nodes = vec![
+            Node {
+                ip: "0.0.0.0".to_string(),
+                connections: vec![1, 2],
+                ..Default::default()
+            },
+            Node {
+                ip: "1.0.0.0".to_string(),
+                connections: vec![0, 2],
+                ..Default::default()
+            },
+            Node {
+                ip: "2.0.0.0".to_string(),
+                connections: vec![0, 1],
+                ..Default::default()
+            },
+        ];
+
+        let peer = Peer::generate_peerlist_for_node(nodes.get(0).unwrap(), &nodes);
+        assert_eq!(peer.list.len(), 2);
+        assert!(peer
+            .list
+            .contains(&IpAddr::from_str(&nodes.get(1).unwrap().ip).unwrap()));
+        assert!(peer
+            .list
+            .contains(&IpAddr::from_str(&nodes.get(2).unwrap().ip).unwrap()));
+    }
+}


### PR DESCRIPTION
This is the first refactoring commit (out of two) which cut peerlist generation into smaller pieces which made possible to split generation into two main parts:

- security one - where will be put: finding islands, bridges, hot nodes detection, checking if removing some nodes can fragment network;
- optimization one - MCDA.

 