### PR TITLE
refactor: remove current peerlist

### DIFF
--- a/src/ips/algorithm.rs
+++ b/src/ips/algorithm.rs
@@ -196,7 +196,7 @@ impl Ips {
                 peer_ratings.sort_by(|a, b| b.rating.partial_cmp(&a.rating).unwrap());
 
                 // Remove peers that are already in peerlist
-                peer_ratings.retain(|x| !curr_peer_ratings.contains(&x));
+                peer_ratings.retain(|x| !curr_peer_ratings.contains(x));
 
                 let mut candidates = peer_ratings
                     .iter()
@@ -220,7 +220,11 @@ impl Ips {
                 }
 
                 // Write new node set
-                final_state.nodes[node_idx].connections = curr_peer_ratings.iter().map(|x| x.index).collect::<Vec<usize>>().to_vec();
+                final_state.nodes[node_idx].connections = curr_peer_ratings
+                    .iter()
+                    .map(|x| x.index)
+                    .collect::<Vec<usize>>()
+                    .to_vec();
             }
         }
 


### PR DESCRIPTION
That would allow to compare algorithm state at any point by just re-calulcating state.
To achieve this we simply ensure working only on node's connections instead of separate peer lists.