### PR TITLE
fix: when creating new connection add it to the other's side list also

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,56 +100,60 @@ Median: 1.0408706699768735
 Min: 0.009224464066643153, max: 1.338099762915545, delta: 1.3288752988489019
 ----------------------------------------
 
+
 Statistics for the final network:
 ----------------------------------------
 Nodes count: 2472
 
 Degree measures:
-Average: 350.2698220064725
-Median: 363
-Min: 5, max: 472, delta: 467
+Average: 349.4037216828479
+Median: 364
+Min: 6, max: 464, delta: 458
 
 Betweenness measures:
-Average: 0.00020269986625605759
-Median: 0.00021142414089966258
+Average: 0.000202632404811459
+Median: 0.0002134929923408508
 Min: 0.000000011402470586985047, max: 0.0005637115400558378, delta: 0.0005637001375852508
 
 Closeness measures:
-Average: 2.000959540368865
-Median: 1.999216689819378
+Average: 2.00074154309123
+Median: 1.999510851620058
 Min: 1.996533523649682, max: 2.995343149165006, delta: 0.9988096255153243
 
 Eigenvector measures:
-Average: 1.0000000000000013
-Median: 1.0369942301865014
-Min: 0.015083344270596788, max: 1.3408045956582166, delta: 1.3257212513876198
+Average: 0.9999999999999986
+Median: 1.040565271198553
+Min: 0.01793917429148585, max: 1.319358717826537, delta: 1.301419543535051
 ----------------------------------------
 
+Comparing if network parameters got changed on plus or minus:
 Deltas for given statistics pair:
 ----------------------------------------
 Nodes count: 0
 
 Degree measures:
-Average: 2.4296116504854695
-Median: 1
-Min: 1, max: 4, delta: 3
+Average: 1.563511326860862
+Median: 2
+Min: 2, max: -4, delta: -6
 
 Betweenness measures:
-Average: 0.0000000044613489560356
-Median: -0.0000017355446652003617
+Average: -0.00000006300009564255845
+Median: 0.0000003333067759878441
 Min: 0, max: 0, delta: 0
 
 Closeness measures:
-Average: 0.000030119448445109498
-Median: 0.0009182323970426953
+Average: -0.00018787782919016394
+Median: 0.001212394197722677
 Min: 0, max: 0, delta: 0
 
 Eigenvector measures:
-Average: -0.0000000000000011102230246251565
-Median: -0.0038764397903721104
-Min: 0.005858880203953636, max: 0.0027048327426715257, delta: -0.0031540474612821168
+Average: -0.000000000000003885780586188048
+Median: -0.00030539877832058693
+Min: 0.008714710224842699, max: -0.0187410450890082, delta: -0.027455755313850805
 ----------------------------------------
 ```
+
+Output can contain also information about some problems found, like nodes with assymetric connections, or nodes connected to themselves.
 
 Example:
 ```

--- a/src/ips/algorithm.rs
+++ b/src/ips/algorithm.rs
@@ -78,10 +78,7 @@ impl Ips {
         // have the node in their connections.
         for (idx, node) in state.nodes.iter().enumerate() {
             if node.connections.contains(&idx) {
-                println!(
-                    "{} is connected to itself.",
-                    node.addr
-                );
+                println!("{} is connected to itself.", node.addr);
             }
 
             for peer in &node.connections {
@@ -196,9 +193,7 @@ impl Ips {
             // Remove potential peers identified to have too high degree and have already
             // been processed by the algorithm
             peer_ratings.retain(|x| {
-                final_state.nodes[x.index]
-                    .connections
-                    .len()
+                final_state.nodes[x.index].connections.len()
                     < working_state.nodes[x.index].connections.len()
             });
 
@@ -239,18 +234,12 @@ impl Ips {
                     .iter()
                     .filter(|x| {
                         // Check if we're not adding a node that is already connected to us
-                        if final_state.nodes[x.index]
-                            .connections
-                            .contains(&node_idx)
-                        {
+                        if final_state.nodes[x.index].connections.contains(&node_idx) {
                             return false;
                         }
 
                         // Check if we're not adding a node that is already connected to us
-                        if final_state.nodes[node_idx]
-                            .connections
-                            .contains(&x.index)
-                        {
+                        if final_state.nodes[node_idx].connections.contains(&x.index) {
                             return false;
                         }
 
@@ -286,7 +275,9 @@ impl Ips {
                 // Eliminate duplicates, the node itself and shrink vector
                 final_state.nodes[node_idx].connections.sort();
                 final_state.nodes[node_idx].connections.dedup();
-                final_state.nodes[node_idx].connections.retain(|x| *x != node_idx);
+                final_state.nodes[node_idx]
+                    .connections
+                    .retain(|x| *x != node_idx);
                 final_state.nodes[node_idx].connections.shrink_to_fit();
             }
         }

--- a/src/ips/algorithm.rs
+++ b/src/ips/algorithm.rs
@@ -74,7 +74,7 @@ impl Ips {
 
     /// Generate peer list - main function with The Algorithm
     pub async fn generate(&mut self, state: &CrunchyState) -> Vec<Peer> {
-        // Sanity check that each node is really connected to it's peers and the peers also
+        // Sanity check that each node is really connected to its peers and the peers also
         // have the node in their connections.
         for (idx, node) in state.nodes.iter().enumerate() {
             if node.connections.contains(&idx) {

--- a/src/ips/algorithm.rs
+++ b/src/ips/algorithm.rs
@@ -74,6 +74,26 @@ impl Ips {
 
     /// Generate peer list - main function with The Algorithm
     pub async fn generate(&mut self, state: &CrunchyState) -> Vec<Peer> {
+        // Sanity check that each node is really connected to it's peers and the peers also
+        // have the node in their connections.
+        for (idx, node) in state.nodes.iter().enumerate() {
+            if node.connections.contains(&idx) {
+                println!(
+                    "{} is connected to itself.",
+                    node.addr
+                );
+            }
+
+            for peer in &node.connections {
+                if !state.nodes[*peer].connections.contains(&idx) {
+                    println!(
+                        "{} is not connected to {} but {} have a connection to it",
+                        node.addr, state.nodes[*peer].addr, node.addr
+                    );
+                }
+            }
+        }
+
         // This is the working set of factors.
         //TODO(asmie): add .clone() to the initial_state when it will be used and remove creating new vector
         // Now we're creating a new vector because MCDA code operates not on state but on the peerlist
@@ -141,12 +161,9 @@ impl Ips {
             // that level. That could be bad if graph's vertexes have very high (or low) degrees
             // and therefore, delta is very high (or low) too. But until we have some better idea
             // this one is the best we can do to keep up with the graph.
-            let desired_degree = ((degree_avg + degree as f64) / 2.0).round() as u32;
+            let desired_degree = degree_avg.round() as u32;
 
             // 3 - Calculate how many peers to add or delete from peerlist
-            //TODO(asmie): when graph has been visualized it occured that it has many nodes with
-            // self connections. This is not good as it takes place in peerlist and gives no
-            // benefit.
             let mut peers_to_delete_count = if desired_degree < degree {
                 degree.saturating_sub(desired_degree)
             } else {
@@ -176,6 +193,24 @@ impl Ips {
                 peers_to_add_count = self.config.change_no_more;
             }
 
+            // Remove potential peers identified to have too high degree and have already
+            // been processed by the algorithm
+            peer_ratings.retain(|x| {
+                final_state.nodes[x.index]
+                    .connections
+                    .len()
+                    < working_state.nodes[x.index].connections.len()
+            });
+
+            // Remove nodes that reached max conn limit
+            peer_ratings.retain(|x| {
+                final_state.nodes[x.index]
+                    .connections
+                    .len()
+                    .abs_diff(working_state.nodes[x.index].connections.len())
+                    <= self.config.change_no_more as usize
+            });
+
             // Remove node itself to ensure we don't add it to peerlist
             peer_ratings.retain(|x| x.index != node_idx);
 
@@ -200,11 +235,27 @@ impl Ips {
                 // Sort peers by rating
                 peer_ratings.sort_by(|a, b| b.rating.partial_cmp(&a.rating).unwrap());
 
-                // Remove peers that are already in peerlist
-                peer_ratings.retain(|x| !curr_peer_ratings.contains(x));
-
                 let mut candidates = peer_ratings
                     .iter()
+                    .filter(|x| {
+                        // Check if we're not adding a node that is already connected to us
+                        if final_state.nodes[x.index]
+                            .connections
+                            .contains(&node_idx)
+                        {
+                            return false;
+                        }
+
+                        // Check if we're not adding a node that is already connected to us
+                        if final_state.nodes[node_idx]
+                            .connections
+                            .contains(&x.index)
+                        {
+                            return false;
+                        }
+
+                        true
+                    })
                     .take((peers_to_add_count * 2) as usize) // Take twice as many candidates
                     .copied()
                     .collect::<Vec<_>>();
@@ -222,6 +273,7 @@ impl Ips {
 
                 for peer in candidates.iter().take(peers_to_add_count as usize) {
                     curr_peer_ratings.push(*peer);
+                    final_state.nodes[peer.index].connections.push(node_idx);
                 }
 
                 // Write new node set
@@ -230,6 +282,12 @@ impl Ips {
                     .map(|x| x.index)
                     .collect::<Vec<usize>>()
                     .to_vec();
+
+                // Eliminate duplicates, the node itself and shrink vector
+                final_state.nodes[node_idx].connections.sort();
+                final_state.nodes[node_idx].connections.dedup();
+                final_state.nodes[node_idx].connections.retain(|x| *x != node_idx);
+                final_state.nodes[node_idx].connections.shrink_to_fit();
             }
         }
 


### PR DESCRIPTION
Adding new connection cannot be done only on one side but also on the peer side. This allows to trace how many connections has been already added, preventing nodes to add too many connections to highest rated nodes. Lack of this fix resulted in creating couple hot nodes with very high degrees, because their rating was high enough for about 40% nearest nodes. Moreover, lack of this fix resulted in omitting hard limit of one node's changes.

Added also starting check for node's connections consistency checking:
- if there are any nodes connected to themselves;
- if there are any nodes connected to some peers that haven't that node in their connection list.