### PR TITLE
feat: added check if network can be easily fragmented by removing hot nodes

### DIFF
--- a/src/ips/algorithm.rs
+++ b/src/ips/algorithm.rs
@@ -108,10 +108,24 @@ impl Ips {
         // new connections between the possible islands.
 
         // Detect islands
-        // To reconsider if islands should be merged prior to any other computations or not.
-        // IMHO, if there are islands they can influence on the results of the computations.
-        // TODO(asmie): Merging islands is not implemented yet.
-        let _islands = self.detect_islands(&working_state.nodes);
+        let islands = self.detect_islands(&working_state.nodes);
+        if islands.len() > 1 {
+            // Check if we're talking about massive islands or just a few nodes
+            let mut massive_islands_count = 0;
+            for island in &islands {
+                // Check if any island is more than 10% of the network
+                if island.len() > &working_state.nodes.len() * 10 / 100 {
+                    massive_islands_count += 1;
+                }
+            }
+
+            if massive_islands_count > 1 {
+                // We need to break here. Merging big islands can be a very complex task especially
+                // when they started to live their lives and created their own blockchain history
+                // after separation.
+                panic!("There are more than one massive island in the network. It is not possible to merge them automatically.");
+            }
+        }
 
         // Now take the current params
         let degree_avg = degree_centrality_avg(&working_state.degrees);

--- a/src/ips/algorithm.rs
+++ b/src/ips/algorithm.rs
@@ -92,9 +92,6 @@ impl Ips {
         }
 
         // This is the working set of factors.
-        //TODO(asmie): add .clone() to the initial_state when it will be used and remove creating new vector
-        // Now we're creating a new vector because MCDA code operates not on state but on the peerlist
-        // and if we left here peerlist from the state, it would be doubled by MCDA.
         let working_state = self.generate_state(&state.nodes);
         let mut final_state = working_state.clone();
 


### PR DESCRIPTION
Network fragmentation cases.

Checking if network can be easily fragmented by attacking 10% of the nodes and if so, preventing such case by creating new connections between their neighbours.

Checking for massive islands in the input data. Merging two massive islands can be risky and shouldn't be done automatic. Both islands could be disconnected for a long time and therefore they can have their own blockchain history and their own reality.