### PR TITLE
refactor: changed MCDA wieghts to produce better output

### DIFF
--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -19,7 +19,7 @@ bridge_threshold_adjustment = 1.25
 
 [ips_config.mcda_weights]
 location = 0.3
-degree = 0.25
-eigenvector = 0.1
-betweenness = 0.25
+degree = -0.3
+eigenvector = 0.2
+betweenness = -0.3
 closeness = 0.1


### PR DESCRIPTION
After testing on real world bigger networks, MCDA wieghts have been updated to produce better overall network results.

Rationale:
Degree and betweenness should have negative weights to penalize nodes which already have many connections and are "hot" nodes with a lot of traffic. That means also the nodes with lower values of both factors are promoted to be taken as new peers first.

Location is the greatest promoting factor which makes that nodes choose peers from the best but closer ones. This prevent from creating many long distance connections between the best possible peers all over the world without knowledge about their performance (or network quality on that link) which is usually better for nearer peers.

IPS is also now promoting nodes with higher values of eigenvector centrality as they can lead the node to the other peers which has much influence on the network.

Closeness is one of the most neutral factor with lowest promotion (but still promotion) just to be sure that algorithm would keep the network more dense.