### PR TITLE
feat: `num_threads` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
+# crunchy
+
 [![dependency status](https://deps.rs/repo/github/runziggurat/crunchy/status.svg)](https://deps.rs/repo/github/runziggurat/crunchy)
 
-# crunchy
 P2P network crawler data cruncher for graph metrics
-
 
 # Running
 
@@ -61,6 +61,8 @@ Options:
   -o, --out-state <OUT_STATE>          Output file with state of the graph (overrides output from config file)
   -g, --geocache-file <GEOCACHE_FILE>  Output file with geolocation cache (overrides cache from config file)
   -c, --config-file <CONFIG_FILE>      Configuration file path (if none defaults will be assumed)
+  -p, --ips-file <IPS_FILE>            Intelligent Peer Sharing output file path (overrides ips from config file)
+  -j, --num-threads <NUM_THREADS>      Number of threads to use for calculations (overrides number of threads from config file)
   -f, --filter-type <FILTER_TYPE>      Optional node filtering parameter, currently supported values:
                                           Zcash
                                           Ripple

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,8 @@ use crate::ips::config::IPSConfiguration;
 
 /// Default number of days to keep each entry in cache
 pub const DEFAULT_KEEP_IN_CACHE_DAYS: u16 = 14;
+/// Default number of threads to use
+pub const DEFAULT_NUM_THREADS: usize = 8;
 
 /// Main configuration structure
 #[derive(Debug, Clone, Deserialize)]
@@ -22,6 +24,8 @@ pub struct CrunchyConfiguration {
     pub ips_config: IPSConfiguration,
     /// Optional node filtering
     pub network_type_filter: Option<NetworkType>,
+    /// Number of threads to use
+    pub num_threads: usize,
 }
 
 /// Configuration for GeoIP module
@@ -70,6 +74,7 @@ impl Default for CrunchyConfiguration {
             ips_config: IPSConfiguration::default(),
             geoip_config: GeoIPConfiguration::default(),
             network_type_filter: None,
+            num_threads: DEFAULT_NUM_THREADS,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::PathBuf};
+use std::{fs, path::PathBuf, thread};
 
 use anyhow::Result;
 use serde::Deserialize;
@@ -8,8 +8,6 @@ use crate::ips::config::IPSConfiguration;
 
 /// Default number of days to keep each entry in cache
 pub const DEFAULT_KEEP_IN_CACHE_DAYS: u16 = 14;
-/// Default number of threads to use
-pub const DEFAULT_NUM_THREADS: usize = 8;
 
 /// Main configuration structure
 #[derive(Debug, Clone, Deserialize)]
@@ -74,7 +72,7 @@ impl Default for CrunchyConfiguration {
             ips_config: IPSConfiguration::default(),
             geoip_config: GeoIPConfiguration::default(),
             network_type_filter: None,
-            num_threads: DEFAULT_NUM_THREADS,
+            num_threads: thread::available_parallelism().unwrap().get(),
         }
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,1 +1,0 @@
-pub const NUM_THREADS: usize = 8;

--- a/src/ips/algorithm.rs
+++ b/src/ips/algorithm.rs
@@ -674,12 +674,12 @@ mod tests {
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
         str::FromStr,
+        thread,
     };
 
     use spectre::{edge::Edge, graph::Graph};
 
     use super::*;
-    use crate::config::DEFAULT_NUM_THREADS;
 
     pub const ERR_PARSE_IP: &str = "failed to parse IP address";
 
@@ -706,7 +706,8 @@ mod tests {
             },
         ];
 
-        let state = ips.generate_state(&nodes, true, DEFAULT_NUM_THREADS);
+        let num_threads = thread::available_parallelism().unwrap().get();
+        let state = ips.generate_state(&nodes, true, num_threads);
 
         assert_eq!(ips.rate_node(nodes.get(0).unwrap(), &state), 10.0);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,10 +170,10 @@ pub struct ArgConfiguration {
 #[cfg(test)]
 mod tests {
 
-    use std::net::SocketAddr;
+    use std::{net::SocketAddr, thread};
 
     use super::*;
-    use crate::config::{GeoIPConfiguration, DEFAULT_NUM_THREADS};
+    use crate::config::GeoIPConfiguration;
 
     #[tokio::test]
     async fn create_nodes_unfiltered_test() {
@@ -183,13 +183,14 @@ mod tests {
         let mut geo_cache = GeoIPCache::new(&config);
         geo_cache.configure_providers(&config);
 
+        let num_threads = thread::available_parallelism().unwrap().get();
         let nodes = create_nodes(
             None,
             &response.result.nodes_indices,
             &response.result.node_addrs,
             &response.result.node_network_types,
             &geo_cache,
-            DEFAULT_NUM_THREADS,
+            num_threads,
         )
         .await;
 
@@ -219,13 +220,15 @@ mod tests {
         let config = GeoIPConfiguration::default();
         let mut geo_cache = GeoIPCache::new(&config);
         geo_cache.configure_providers(&config);
+
+        let num_threads = thread::available_parallelism().unwrap().get();
         let nodes = create_nodes(
             Some(NetworkType::Zcash),
             &indices,
             &node_addrs,
             &node_network_types,
             &geo_cache,
-            DEFAULT_NUM_THREADS,
+            num_threads,
         )
         .await;
         assert_eq!(nodes.len(), 2);
@@ -241,13 +244,14 @@ mod tests {
         let mut geo_cache = GeoIPCache::new(&config);
         geo_cache.configure_providers(&config);
 
+        let num_threads = thread::available_parallelism().unwrap().get();
         let nodes = create_nodes(
             Some(NetworkType::Zcash),
             &response.result.nodes_indices,
             &response.result.node_addrs,
             &response.result.node_network_types,
             &geo_cache,
-            DEFAULT_NUM_THREADS,
+            num_threads,
         )
         .await;
         assert_eq!(nodes.len(), 122);

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,15 +156,15 @@ pub struct ArgConfiguration {
     /// Configuration file path (if none defaults will be assumed)
     #[clap(short, long, value_parser)]
     pub config_file: Option<PathBuf>,
-    /// Optional node filtering parameter; consult Readme for possible values
-    #[clap(short, long, value_parser)]
-    pub filter_type: Option<NetworkType>,
-    /// Intelligent Peer Sharing output file path (overrides filter type from config file)
+    /// Intelligent Peer Sharing output file path (overrides ips from config file)
     #[clap(short = 'p', long, value_parser)]
     pub ips_file: Option<PathBuf>,
     /// Number of threads to use for calculations (overrides number of threads from config file)
     #[clap(short = 'j', long, value_parser)]
     pub num_threads: Option<usize>,
+    /// Optional node filtering parameter; consult Readme for possible values
+    #[clap(short, long, value_parser)]
+    pub filter_type: Option<NetworkType>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR introduces:
- `num_threads` argument, that can be passed to control how many threads `spectre` computations will use. By default, ~~it will use as many as specified by `DEFAULT_NUM_THREADS`~~ it will guess the number of threads to use with `std::thread::available_parallelism`.